### PR TITLE
Explicitly zero-initialize fields to avoid undefined behavior

### DIFF
--- a/cs237-library/src/application.cpp
+++ b/cs237-library/src/application.cpp
@@ -37,7 +37,8 @@ Application::Application (std::vector<const char *> &args, std::string const &na
   : _name(name),
     _messages(VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT),
     _debug(0),
-    _gpu(VK_NULL_HANDLE)
+    _gpu(VK_NULL_HANDLE),
+    _propsCache(nullptr)
 {
     // process the command-line arguments
     for (auto it = args.cbegin();  it != args.cend();  ++it) {

--- a/cs237-library/src/window.cpp
+++ b/cs237-library/src/window.cpp
@@ -102,6 +102,11 @@ Window::Window (Application *app, CreateWindowInfo const &info)
     this->_wid = info.wid;
     this->_ht = info.ht;
     this->_isVis = true;
+    this->_keyEnabled = false;
+    this->_cursorPosEnabled = false;
+    this->_cursorEnterEnabled = false;
+    this->_mouseButtonEnabled = false;
+    this->_scrollEnabled = false;
 
     // set up the Vulkan surface for the window
     if (glfwCreateWindowSurface(app->_instance, window, nullptr, &this->_surf) != VK_SUCCESS) {


### PR DESCRIPTION
This pull request resolves some undefined behavior bugs that I've been running into while working on proj2. For reference, I'm using an M1 Macbook Air with MacOS Big Sur.

The first issue has been occurring since the last project, where there's a random chance that all key presses in the window will fail to register when I run the executable. It looks like [the `_keyEnabled` field in the `cs237::Window` class](https://github.com/uchicago-cmsc23700-aut22/cs237-upstream/blob/4379ee1a127ae6aad7294af05de96e302d03fb13/cs237-library/include/cs237-window.hpp#L221-L225) sometimes has a value of 1 upon initialization; this is causing [the check in `enableKeyEvent` to fail](https://github.com/uchicago-cmsc23700-aut22/cs237-upstream/blob/4379ee1a127ae6aad7294af05de96e302d03fb13/cs237-library/src/window.cpp#L152), which means that the [key callback function is never bound](https://github.com/uchicago-cmsc23700-aut22/cs237-upstream/blob/4379ee1a127ae6aad7294af05de96e302d03fb13/cs237-library/src/window.cpp#L155). Explicitly initializing these fields fixed the issue for me.

The second issue has been causing a Vulkan error on launch and a segfault when the program ends.
The following terminal output contains the Vulkan error:
```
VUID-VkSamplerCreateInfo-anisotropyEnable-01071(ERROR / SPEC): msgNum: 1233543420 - Validation Error: [ VUID-VkSamplerCreateInfo-anisotropyEnable-01071 ] Object 0: handle = 0x7fae1008c418, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x498660fc | vkCreateSampler(): value of pCreateInfo->maxAnisotropy must be in range [1.0, 16.000000] VkPhysicalDeviceLimits::maxSamplerAnistropy, but 0.000000 found. The Vulkan spec states: If anisotropyEnable is VK_TRUE, maxAnisotropy must be between 1.0 and VkPhysicalDeviceLimits::maxSamplerAnisotropy, inclusive (https://vulkan.lunarg.com/doc/view/1.3.224.1/mac/1.3-extensions/vkspec.html#VUID-VkSamplerCreateInfo-anisotropyEnable-01071)
    Objects: 1
        [0] 0x7fae1008c418, type: 3, name: NULL
```
[This line in `application.cpp`](https://github.com/uchicago-cmsc23700-aut22/cs237-upstream/blob/28093d02973a0139497137207c01667dfd786048/cs237-library/src/application.cpp#L70) was causing the segfault.
Both seem to be related to the `_propsCache` field already existing upon initialization—notably, most of the fields appear to be 0, so this doesn't seem like intended behavior. Explicitly initializing this to nullptr also fixed the issue.